### PR TITLE
Adding support for emojis (surrogate pairs)

### DIFF
--- a/lib/xml-entities.js
+++ b/lib/xml-entities.js
@@ -67,10 +67,14 @@ XmlEntities.prototype.decode = function(str) {
                 parseInt(s.substr(3), 16) :
                 parseInt(s.substr(2));
 
-            if (isNaN(code) || code < -32768 || code > 65535) {
+            if (isNaN(code) || code < -32768 || (code > 65535 && code < 128000) || code > 128599) {
                 return '';
+            } else if (code > 128000 && code < 128599) {
+                var surrogatePair = String.fromCodePoint(code);
+                return String.fromCharCode(surrogatePair.charCodeAt(0), surrogatePair.charCodeAt(1));
+            } else {
+                return String.fromCharCode(code);
             }
-            return String.fromCharCode(code);
         }
         return ALPHA_INDEX[s] || s;
     });


### PR DESCRIPTION
Adds support for character code range 128000-128599 (emojis). Extracts the character's surrogate pairs and returns them so that emojis are rendered.

Please feel free to suggest any changes -- I'm not 100% confident about all of the cases and how this library works, but this adds support for emojis for me.

For example, it takes `&#128514;` 😂 and finds the surrogates 55357 and 56834.
