### PR TITLE
Fix typo

### DIFF
--- a/lib/xml-entities.js
+++ b/lib/xml-entities.js
@@ -129,10 +129,10 @@ XmlEntities.prototype.encodeNonASCII = function(str) {
     if (!str || !str.length) {
         return '';
     }
-    var strLenght = str.length;
+    var strLength = str.length;
     var result = '';
     var i = 0;
-    while (i < strLenght) {
+    while (i < strLength) {
         var c = str.charCodeAt(i);
         if (c <= 255) {
             result += str[i++];


### PR DESCRIPTION
- Fix typo in the `var` name.
- Resolves https://github.com/mdevils/node-html-entities/issues/32