### PR TITLE
Add file extenstion to typings & types property

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "url": "https://github.com/mdevils/node-html-entities.git"
   },
   "main": "./lib/index.js",
-  "typings": "./lib/index",
-  "types": "./lib/index",
+  "typings": "./lib/index.d.ts",
+  "types": "./lib/index.d.ts",
   "scripts": {
     "test": "mocha --recursive -r ts-node/register test/**/*.ts",
     "benchmark": "ts-node benchmark/benchmark",


### PR DESCRIPTION
TypeScript requires the file extension be specified in typings / types property. https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

(they are also synonymous, so one or the other could be removed as well)