### PR TITLE
Handle undefined and null

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,9 @@ export function encode(
     text: string | undefined | null,
     {mode = 'specialChars', numeric = 'decimal', level = 'all'}: EncodeOptions = defaultEncodeOptions
 ) {
-    if (!text) return '';
+    if (!text) {
+        return '';
+    }
     const references = allNamedReferences[level].characters;
     const isHex = numeric === 'hexadecimal';
 
@@ -73,7 +75,9 @@ export function decode(
     text: string | undefined | null,
     {level = 'all', scope = level === 'xml' ? 'strict' : 'body'}: DecodeOptions = defaultDecodeOptions
 ) {
-    if (!text) return '';
+    if (!text) {
+        return '';
+    }
     const references = allNamedReferences[level].entities;
     const isAttribute = scope === 'attribute';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,11 +39,13 @@ const defaultEncodeOptions: EncodeOptions = {
 };
 
 export function encode(
-    text: string,
+    text: string | undefined | null,
     {mode = 'specialChars', numeric = 'decimal', level = 'all'}: EncodeOptions = defaultEncodeOptions
 ) {
+    if (!text) return '';
     const references = allNamedReferences[level].characters;
     const isHex = numeric === 'hexadecimal';
+
     return text.replace(encodeRegExps[mode], function (input) {
         const entity = references[input];
         if (entity) {
@@ -68,9 +70,10 @@ const decodeRegExps: Record<DecodeScope, RegExp> = {
 const fromCharCode = String.fromCharCode;
 
 export function decode(
-    text: string,
+    text: string | undefined | null,
     {level = 'all', scope = level === 'xml' ? 'strict' : 'body'}: DecodeOptions = defaultDecodeOptions
 ) {
+    if (!text) return '';
     const references = allNamedReferences[level].entities;
     const isAttribute = scope === 'attribute';
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,6 +5,12 @@ import * as HE from '../src';
 const {encode, decode} = require(process.env.TEST_LIB ? '../lib' : '../src') as typeof HE;
 
 describe('encode()', () => {
+    it('should handle undefined', () => {
+        expect(decode(undefined)).to.equal('');
+    });
+    it('should handle null', () => {
+        expect(decode(null)).to.equal('');
+    });
     it('should handle empty string', () => {
         expect(encode('')).to.equal('');
     });
@@ -50,6 +56,12 @@ describe('encode()', () => {
 });
 
 describe('decode()', () => {
+    it('should handle undefined', () => {
+        expect(decode(undefined)).to.equal('');
+    });
+    it('should handle null', () => {
+        expect(decode(null)).to.equal('');
+    });
     it('should handle empty string', () => {
         expect(decode('')).to.equal('');
     });


### PR DESCRIPTION
Since v2.0.0, undefined and null values passed into encode/decode results in errors such as:

```TypeError: Cannot read property 'replace' of null```

Since values returned from the back-end could result in either undefined or null values, I'd love for the library to continue to handle such cases. When using Typescript, I frequently use Optional Chaining which safely returns an undefined value in case of value not defined deep down in the chain.

I hope this is a welcome change, thanks!