### PR TITLE
fix(package.json): specify `sideEffects` false

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "type": "git",
     "url": "https://github.com/mdevils/html-entities.git"
   },
+  "sideEffects": false,
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
This package doesn't have any side effects and thus can specify
`sideEffects: false` in its `package.json` file to tell code bundlers to
exclude it from the client-side bundle when it is found in, for example,
[Remix routes](https://remix.run/docs/en/v1/pages/gotchas#server-code-in-client-bundles)