### PR TITLE
feat: nonAsciiPrintableOnly mode, closes #84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2.4.0
+-----
+
+* Introduce `nonAsciiPrintableOnly` mode.
+
 2.3.4
 -----
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Usage
 
 ### encode(text, options)
 
-Encodes text replacing HTML special characters (`<>&"'`) plus other character ranges depending on `mode` option value.
+Encodes text replacing HTML special characters (`<>&"'`) and/or other character ranges depending on `mode` option value.
 
 ```js
 import {encode} from 'html-entities';
@@ -30,6 +30,9 @@ encode('< ©', {mode: 'nonAsciiPrintable'});
 
 encode('< ©', {mode: 'nonAsciiPrintable', level: 'xml'});
 // -> '&lt; &#169;'
+
+encode('< > " \' & ©', {mode: 'nonAsciiPrintableOnly', level: 'xml'});
+// -> '< > " \' & &#169;'
 ```
 
 Options:
@@ -44,8 +47,9 @@ Options:
 #### mode
 
  * `specialChars` encodes only HTML special characters (default).
- * `nonAscii` encodes HTML special characters and everything outside of the [ASCII character range](https://en.wikipedia.org/wiki/ASCII).
+ * `nonAscii` encodes HTML special characters and everything outside the [ASCII character range](https://en.wikipedia.org/wiki/ASCII).
  * `nonAsciiPrintable` encodes HTML special characters and everything outiside of the [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#Printable_characters).
+ * `nonAsciiPrintableOnly` everything outiside of the [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#Printable_characters) keeping HTML special characters intact.
  * `extensive` encodes all non-printable characters, non-ASCII characters and all characters with named references.
 
 #### numeric

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ interface CommonOptions {
     level?: Level;
 }
 
-export type EncodeMode = 'specialChars' | 'nonAscii' | 'nonAsciiPrintable' | 'extensive';
+export type EncodeMode = 'specialChars' | 'nonAscii' | 'nonAsciiPrintable' | 'nonAsciiPrintableOnly' | 'extensive';
 
 export interface EncodeOptions extends CommonOptions {
     mode?: EncodeMode;
@@ -58,9 +58,10 @@ export interface DecodeOptions extends CommonOptions {
 
 const encodeRegExps: Record<EncodeMode, RegExp> = {
     specialChars: /[<>'"&]/g,
-    nonAscii: /(?:[<>'"&\u0080-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])/g,
-    nonAsciiPrintable: /(?:[<>'"&\x01-\x08\x11-\x15\x17-\x1F\x7f-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])/g,
-    extensive: /(?:[\x01-\x0c\x0e-\x1f\x21-\x2c\x2e-\x2f\x3a-\x40\x5b-\x60\x7b-\x7d\x7f-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])/g
+    nonAscii: /[<>'"&\u0080-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/g,
+    nonAsciiPrintable: /[<>'"&\x01-\x08\x11-\x15\x17-\x1F\x7f-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/g,
+    nonAsciiPrintableOnly: /[\x01-\x08\x11-\x15\x17-\x1F\x7f-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/g,
+    extensive: /[\x01-\x0c\x0e-\x1f\x21-\x2c\x2e-\x2f\x3a-\x40\x5b-\x60\x7b-\x7d\x7f-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/g
 };
 
 const defaultEncodeOptions: EncodeOptions = {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -29,6 +29,9 @@ describe('encode()', () => {
             expect(encode('a\n<>"\'&©∆℞😂\0\x01', {mode: 'nonAsciiPrintable'})).to.equal(
                 'a\n&lt;&gt;&quot;&apos;&amp;&copy;&#8710;&rx;&#128514;\0&#1;'
             );
+            expect(encode('a\n<>"\'&©∆℞😂\0\x01', {mode: 'nonAsciiPrintableOnly'})).to.equal(
+                'a\n<>"\'&&copy;&#8710;&rx;&#128514;\0&#1;'
+            );
             expect(encode('a\n<>"\'&©∆℞😂\0\x01', {mode: 'extensive'})).to.equal(
                 'a&NewLine;&lt;&gt;&quot;&apos;&amp;&copy;&#8710;&rx;&#128514;\0&#1;'
             );


### PR DESCRIPTION
Introduces `nonAsciiPrintableOnly` mode.

Example:
```
encode('< > " \' & ©', {mode: 'nonAsciiPrintableOnly', level: 'xml'});
// -> '< > " \' & &#169;'
```