### PR TITLE
perf: slice is faster

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,8 +121,8 @@ function getDecodedEntity(
             const decodeSecondChar = entity[2];
             const decodeCode =
                 decodeSecondChar == 'x' || decodeSecondChar == 'X'
-                    ? parseInt(entity.substr(3), 16)
-                    : parseInt(entity.substr(2));
+                    ? parseInt(entity.slice(3), 16)
+                    : parseInt(entity.slice(2));
 
             decodeResult =
                 decodeCode >= 0x10ffff


### PR DESCRIPTION
https://www.measurethat.net/Benchmarks/Show/2335/1/slice-vs-substr-vs-substring-with-no-end-index#latest_results_block

```
slice x 25,768,061 ops/sec ±10.38% (42 runs sampled)
substr x 23,764,229 ops/sec ±8.05% (42 runs sampled)
substring x 24,512,322 ops/sec ±10.47% (29 runs sampled)
```